### PR TITLE
Check for document fragments in toElement

### DIFF
--- a/packages/metal-dom/src/domNamed.js
+++ b/packages/metal-dom/src/domNamed.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { isDef, isDocument, isElement, isObject, isString, object } from 'metal';
+import { isDef, isDocument, isDocumentFragment, isElement, isObject, isString, object } from 'metal';
 import domData from './domData';
 import DomDelegatedEventHandle from './DomDelegatedEventHandle';
 import DomEventHandle from './DomEventHandle';
@@ -672,7 +672,7 @@ function triggerDelegatedListeners_(container, event, defaultFns) {
  * @return {Element} The converted element, or null if none was found.
  */
 export function toElement(selectorOrElement) {
-	if (isElement(selectorOrElement) || isDocument(selectorOrElement)) {
+	if (isElement(selectorOrElement) || isDocument(selectorOrElement) || isDocumentFragment(selectorOrElement)) {
 		return selectorOrElement;
 	} else if (isString(selectorOrElement)) {
 		if (selectorOrElement[0] === '#' && selectorOrElement.indexOf(' ') === -1) {

--- a/packages/metal-dom/test/dom.js
+++ b/packages/metal-dom/test/dom.js
@@ -1260,6 +1260,17 @@ describe('dom', function() {
 			assert.strictEqual(null, dom.toElement(1));
 			assert.strictEqual(null, dom.toElement(null));
 		});
+
+		it('should return matching element if selector is document fragment', function () {
+			var frag1 = document.createDocumentFragment();
+			assert.strictEqual(frag1, dom.toElement(frag1));
+
+			var frag2 = document.createDocumentFragment();
+			assert.strictEqual(frag2, dom.toElement(frag2));
+
+			var frag3 = '#document-fragment';
+			assert.notStrictEqual(frag3, dom.toElement(frag3));
+		});
 	});
 
 	describe('supportsEvent', function() {

--- a/packages/metal/src/coreNamed.js
+++ b/packages/metal/src/coreNamed.js
@@ -201,6 +201,15 @@ export function isDocument(val) {
 }
 
 /**
+ * Returns true if value is a document-fragment.
+ * @param {*} val
+ * @return {boolean}
+ */
+export function isDocumentFragment(val) {
+	return val && typeof val === 'object' && val.nodeType === 11;
+}
+
+/**
  * Returns true if value is a dom element.
  * @param {*} val
  * @return {boolean}

--- a/packages/metal/test/core.js
+++ b/packages/metal/test/core.js
@@ -207,6 +207,13 @@ describe('core', function() {
 			assert.ok(!core.isDocument(true));
 		});
 
+		it('should check if var is document fragment', function () {
+			assert.ok(!core.isDocumentFragment(null));
+			assert.ok(!core.isDocumentFragment({nodeType: 0}));
+			assert.ok(!core.isDocumentFragment({nodeType: 9}));
+			assert.ok(core.isDocumentFragment({nodeType: 11}));
+		});
+
 		it('should check if var is window', function() {
 			if (typeof window === 'undefined') {
 				// Skip this test when on node environment.


### PR DESCRIPTION
Hi,

I did check the guidlines (and hope I didn't miss anything) but the `gulp lint` task did output a lot of warnings, before these changes, I wasn't sure if that was expected.

Thanks