### PR TITLE
Exports Config from metal-soy

### DIFF
--- a/packages/metal-soy/package.json
+++ b/packages/metal-soy/package.json
@@ -27,7 +27,8 @@
     "metal-component": "^2.6.2",
     "metal-dom": "^2.6.0",
     "metal-incremental-dom": "^2.6.2",
-    "metal-soy-bundle": "^2.0.0"
+    "metal-soy-bundle": "^2.0.0",
+    "metal-state": "^2.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",

--- a/packages/metal-soy/src/Soy.js
+++ b/packages/metal-soy/src/Soy.js
@@ -1,8 +1,9 @@
 'use strict';
 
 import 'metal-soy-bundle';
-import { isFunction, isObject, isString, object } from 'metal';
 import { ComponentRegistry } from 'metal-component';
+import { isFunction, isObject, isString, object } from 'metal';
+import { validators, Config } from 'metal-state';
 import HTML2IncDom from 'html2incdom';
 import IncrementalDomRenderer from 'metal-incremental-dom';
 import SoyAop from './SoyAop';
@@ -222,4 +223,9 @@ const soyRenderer_ = new Soy();
 soyRenderer_.RENDERER_NAME = 'soy';
 
 export default soyRenderer_;
-export { soyRenderer_ as Soy, SoyAop };
+export {
+	Config,
+	soyRenderer_ as Soy,
+	SoyAop,
+	validators
+};


### PR DESCRIPTION
This exports `Config` from `metal-soy` in the same way that we do in `metal-jsx`.

Also, I wonder if going forward we should encourage using `Config` instead of doing something like `validator: core.isString`. `Config` seems to be more concise, and provide better feedback (in the form of warnings) when you provide invalid props. It's also more expressive and self-documenting when you need to validate enumerations (`oneOf`).