### PR TITLE
Adds custom element registration for metal components

### DIFF
--- a/karma-coverage.conf.js
+++ b/karma-coverage.conf.js
@@ -33,6 +33,12 @@ module.exports = function(config) {
 				included: true,
 				served: true
 			},
+			{
+				pattern: 'packages/metal-soy/node_modules/@webcomponents/custom-elements/src/*.js',
+				watched: false,
+				included: true,
+				served: true
+			},
 
 			{
 				pattern: 'packages/metal*/test/**/*.js',
@@ -53,6 +59,7 @@ module.exports = function(config) {
 			'packages/metal-incremental-dom/lib/incremental-dom.js': ['browserify'],
 			'packages/metal-soy-bundle/lib/bundle.js': ['browserify'],
 			'packages/metal-soy/node_modules/html2incdom/lib/*.js': ['browserify'],
+			'packages/metal-soy/node_modules/@webcomponents/custom-elements/src/*.js': ['browserify'],
 			'packages/metal*/test/**/*.js': ['browserify']
 		},
 

--- a/karma-sauce.conf.js
+++ b/karma-sauce.conf.js
@@ -33,6 +33,12 @@ module.exports = function(config) {
 				included: true,
 				served: true
 			},
+			{
+				pattern: 'packages/metal-soy/node_modules/@webcomponents/custom-elements/src/*.js',
+				watched: false,
+				included: true,
+				served: true
+			},
 
 			{
 				pattern: 'packages/metal*/test/**/*.js',
@@ -53,6 +59,7 @@ module.exports = function(config) {
 			'packages/metal-incremental-dom/lib/incremental-dom.js': ['browserify'],
 			'packages/metal-soy/node_modules/metal-soy-bundle/lib/bundle.js': ['browserify'],
 			'packages/metal-soy/node_modules/html2incdom/lib/*.js': ['browserify'],
+			'packages/metal-soy/node_modules/@webcomponents/custom-elements/src/*.js': ['browserify'],
 			'packages/metal*/test/**/*.js': ['browserify']
 		},
 

--- a/packages/metal-soy/package.json
+++ b/packages/metal-soy/package.json
@@ -22,6 +22,7 @@
     "metal"
   ],
   "dependencies": {
+    "@webcomponents/custom-elements": "^1.0.0-alpha.3",
     "html2incdom": "^0.1.1",
     "metal": "^2.6.4",
     "metal-component": "^2.7.0",

--- a/packages/metal/src/coreNamed.js
+++ b/packages/metal/src/coreNamed.js
@@ -289,3 +289,48 @@ export function isString(val) {
  */
 export function nullFunction() {
 }
+
+/**
+ * Register a custom element for a given metal component.
+ *
+ * @param {String} tagName The tag name to use for this custom element.
+ * @param {!function()} ctor Metal component constructor.
+ * @param {?Array=} observedAttrs The attributes to be "observed".
+ * @return {void} Nothing.
+ */
+export function defineWebComponent(tagName, ctor, observedAttrs) {
+  class CustomElement extends HTMLElement {
+    constructor() {
+      super();
+    }
+
+    static get observedAttributes() {
+      return observedAttrs;
+    }
+
+    connectedCallback() {
+      let shadowRoot = this.attachShadow({mode: 'open'});
+      let opts = {};
+      if (Array.isArray(observedAttrs)) {
+        for (let i = 0, l = observedAttrs.length; i < l; i++) {
+          opts[observedAttrs[i]] = this.getAttribute(observedAttrs[i]);
+        }
+      }
+      this.component = new ctor(opts, shadowRoot);
+			this.component.on('*', this.emit.bind(this));
+    }
+
+		attributeChangedCallback(attrName, oldVal, newVal) {
+			if (this.component) {
+				this.component[attrName] = newVal;
+			}
+		}
+
+		emit(...data) {
+			const evt = data.pop();
+			this.dispatchEvent(new CustomEvent(evt.type, {detail: data}));
+		}
+  }
+
+  window.customElements.define(tagName, CustomElement);
+}


### PR DESCRIPTION
This is an initial implementation to add "WebComponents" support to metal.

Our initial idea was to be able to use metal components though custom elements, for example

```html
<my-component attr1="value1" attr2="value2"></my-component>
```

In order to do so, one would have to call the `defineWebComponent ` defined in metal's `core` page, like so

```javascript
import { core } from 'metal';
import Component from 'metal-component';

class MyComponent extends Component {
  // ...
}

core.defineWebComponent('my-component', MyComponent, ['attributes', 'to', 'be', 'observed']);
```

I would need some help from you to decide if this method should be defined in the core package, and also to set up travis (maybe these tests shouldn't run in "older" browsers?).

Any comment or feedback would be appreciated.

Thanks.

