### PR TITLE
Adds Custom element support for Metal components

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -142,7 +142,11 @@ function calcDestDir(file) {
 function compileToLib(src) {
 	return gulp.src(src)
 		.pipe(babel({
-			presets: ['es2015']
+			presets: ['es2015'],
+			plugins: [
+				'transform-custom-element-classes',
+				'transform-es2015-classes'
+			],
 		}))
 		.pipe(gulp.dest(calcDestDir));
 }

--- a/karma-coverage.conf.js
+++ b/karma-coverage.conf.js
@@ -33,7 +33,18 @@ module.exports = function(config) {
 				included: true,
 				served: true
 			},
-
+			{
+				pattern: 'packages/metal-custom-element/node_modules/babel-polyfill/dist/polyfill.min.js',
+				watched: false,
+				included: true,
+				served: true
+			},
+			{
+				pattern: 'packages/metal-custom-element/node_modules/webcomponents.js/webcomponents-lite.js',
+				watched: false,
+				included: true,
+				served: true
+			},
 			{
 				pattern: 'packages/metal*/test/**/*.js',
 				watched: false,
@@ -64,7 +75,11 @@ module.exports = function(config) {
 				[
 					'babelify',
 					{
-						plugins: ['istanbul'],
+						plugins: [
+							'transform-custom-element-classes',
+							'transform-es2015-classes',
+							'istanbul'
+						],
 						presets: ['es2015']
 					}
 				]

--- a/karma-sauce.conf.js
+++ b/karma-sauce.conf.js
@@ -33,7 +33,18 @@ module.exports = function(config) {
 				included: true,
 				served: true
 			},
-
+			{
+				pattern: 'packages/metal-custom-element/node_modules/babel-polyfill/dist/polyfill.min.js',
+				watched: false,
+				included: true,
+				served: true
+			},
+			{
+				pattern: 'packages/metal-custom-element/node_modules/webcomponents.js/webcomponents-lite.js',
+				watched: false,
+				included: true,
+				served: true
+			},
 			{
 				pattern: 'packages/metal*/test/**/*.js',
 				watched: false,
@@ -56,13 +67,19 @@ module.exports = function(config) {
 			'packages/metal*/test/**/*.js': ['browserify']
 		},
 
-		browsers: ['Chrome'],
+		browsers: ['IE11 - Win7'],
 
 		browserify: {
 			debug: true,
 			transform: [
-				['babelify', {presets: ['es2015']}]
-			],
+				['babelify', {
+					presets: ['es2015'],
+					plugins: [
+						'transform-custom-element-classes',
+						'transform-es2015-classes'
+					]
+				}
+			]],
 			insertGlobalVars: {
 				METAL_VERSION: function() {
 					return '\'' + lernaJson.version + '\'';

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   },
   "devDependencies": {
     "babel-plugin-istanbul": "^1.0.3",
+    "babel-plugin-transform-custom-element-classes": "^0.1.0",
+    "babel-plugin-transform-es2015-classes": "^6.24.1",
     "babel-preset-es2015": "^6.0.0",
     "babel-preset-metal-jsx": "^0.0.2",
     "babelify": "^7.3.0",

--- a/packages/metal-custom-element/LICENSE.md
+++ b/packages/metal-custom-element/LICENSE.md
@@ -1,0 +1,30 @@
+# Software License Agreement (BSD License)
+
+Copyright (c) 2016, Liferay Inc.
+All rights reserved.
+
+Redistribution and use of this software in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above
+  copyright notice, this list of conditions and the
+  following disclaimer.
+
+* Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the
+  following disclaimer in the documentation and/or other
+  materials provided with the distribution.
+
+* The name of Liferay Inc. may not be used to endorse or promote products
+  derived from this software without specific prior
+  written permission of Liferay Inc.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/packages/metal-custom-element/README.md
+++ b/packages/metal-custom-element/README.md
@@ -1,0 +1,3 @@
+# metal-custom-element
+
+[CustomElement](https://w3c.github.io/webcomponents/spec/custom/) registration for Metal.js components.

--- a/packages/metal-custom-element/package.json
+++ b/packages/metal-custom-element/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "metal-custom-element",
+  "version": "2.7.0",
+  "description": "CustomElement registration for Metal.js components.",
+  "license": "BSD-3-Clause",
+  "repository": "https://github.com/metal/metal.js/tree/master/packages/metal-custom-element",
+  "engines": {
+    "node": ">=0.10.0",
+    "npm": ">=3.0.0"
+  },
+  "files": [
+    "lib",
+    "src"
+  ],
+  "main": "lib/customElement.js",
+  "jsnext:main": "src/customElement.js",
+  "scripts": {
+    "compile": "babel --presets es2015 --plugins=transform-custom-element-classes,transform-es2015-classes -d lib/ src/",
+    "prepublish": "npm run compile"
+  },
+  "keywords": [
+    "javascript",
+    "library"
+  ],
+  "dependencies": {
+    "metal-state": "2.7.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.4.5",
+    "babel-plugin-transform-custom-element-classes": "^0.1.0",
+    "babel-plugin-transform-es2015-classes": "^6.24.1",
+    "babel-polyfill": "^6.23.0",
+    "babel-preset-es2015": "^6.0.0",
+    "metal-component": "2.7.0",
+    "metal-incremental-dom": "^2.7.0",
+    "metal-soy": "2.7.0",
+    "metal-soy-bundle": "^2.7.0",
+    "webcomponents.js": "git+ssh://git@github.com:webcomponents/webcomponentsjs.git"
+  }
+}

--- a/packages/metal-custom-element/src/customElement.js
+++ b/packages/metal-custom-element/src/customElement.js
@@ -1,0 +1,60 @@
+import State from 'metal-state';
+
+/**
+ * Register a custom element for a given metal component.
+ *
+ * @param {String} tagName The tag name to use for this custom element.
+ * @param {!function()} Ctor Metal component constructor.
+ * @return {void} Nothing.
+ */
+export function defineWebComponent(tagName, Ctor) {
+
+	if (!('customElements' in window)) {
+		return;
+	}
+
+	const observedAttrs = Object.keys(State.getStateStatic(Ctor));
+
+	class CustomElement extends HTMLElement {
+		constructor() {
+			super();
+		}
+
+		static get observedAttributes() {
+			return observedAttrs;
+		}
+
+		connectedCallback() {
+			let shadowRoot = this.attachShadow({
+				mode: 'open'
+			});
+			let opts = {};
+			for (let i = 0, l = observedAttrs.length; i < l; i++) {
+				opts[observedAttrs[i]] = this.getAttribute(observedAttrs[i]);
+			}
+			this.component = new Ctor(opts, shadowRoot);
+			this.componentEventHandler = this.emit.bind(this);
+			this.component.on('*', this.componentEventHandler);
+		}
+
+		attributeChangedCallback(attrName, oldVal, newVal) {
+			this.component[attrName] = newVal;
+		}
+
+		disconnectedCallback() {
+			this.component.off('*', this.componentEventHandler);
+			this.component.dispose();
+		}
+
+		emit(...data) {
+			const evtData = data.pop();
+			const evt = new CustomEvent(evtData.type, {detail: data});
+			this.dispatchEvent(evt);
+		}
+	}
+
+	window.customElements.define(tagName, CustomElement);
+};
+
+export default defineWebComponent;
+

--- a/packages/metal-custom-element/test/.eslintrc.json
+++ b/packages/metal-custom-element/test/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "globals": {
+    "assert": true,
+    "sinon": true,
+		"IncrementalDOM": true
+  }
+}

--- a/packages/metal-custom-element/test/customElement.js
+++ b/packages/metal-custom-element/test/customElement.js
@@ -1,0 +1,83 @@
+'use strict';
+
+import Component from 'metal-component';
+import Soy from 'metal-soy';
+import { defineWebComponent } from '../src/customElement';
+
+
+describe('Web components', function() {
+
+	describe('Custom elements', function() {
+		let el;
+
+		afterEach(function() {
+			if (el && document.body.contains(el)) {
+				document.body.removeChild(el);
+			}
+		});
+
+		it('should not throw when creating or appending a custom element', function() {
+			const tagName = createWebComponent('custom-test-element-01');
+
+			function createEl() {
+				el = document.createElement(tagName);
+				return el;
+			}
+
+			function appendEl() {
+				document.body.appendChild(createEl());
+			}
+
+			assert.doesNotThrow(createEl);
+			assert.doesNotThrow(appendEl);
+		});
+
+		it('should have the correct tag name', function() {
+			const tagName = createWebComponent('custom-test-element-02');
+			el = document.createElement(tagName);
+			document.body.appendChild(el);
+			assert.ok(el.tagName.toLowerCase() == tagName);
+		});
+
+		it('should dispatch events when attributes change', function() {
+			const tagName = createWebComponent('custom-test-element-03');
+
+			el = document.createElement(tagName);
+			document.body.appendChild(el);
+
+			const fn = sinon.stub();
+
+			el.addEventListener('titleChanged', fn);
+
+			el.setAttribute('title', 'new title');
+			assert.strictEqual(1, fn.callCount);
+
+			el.setAttribute('non-existing', 'test');
+			assert.strictEqual(1, fn.callCount);
+		});
+	});
+
+	function createWebComponent(name) {
+		const tagName = `metal-test-component-${name}`;
+
+		class WebComponent extends Component {}
+
+		WebComponent.STATE = {
+			title: {
+				value: 'default title'
+			}
+		};
+
+		Soy.register(WebComponent, {
+			render: () => {
+				IncrementalDOM.elementVoid('div', null, [
+					'title', WebComponent.STATE.title.value
+				]);
+			}
+		});
+
+		defineWebComponent(tagName, WebComponent);
+
+		return tagName;
+	}
+});


### PR DESCRIPTION
Hi everyone,

This pull request aims to bring Custom element support for Metal components.

A new "package" named `metal-custom-element` has been introduced for this feature.

The code has been tested on Chrome (`58.0.3029.81`), Firefox (`53.0`), but also IE11 (`11.0.0`) and Microsoft Edge (`14.14393.0`) with [ievms](https://github.com/xdissent/ievms) and the [karam-ievms-launcher](https://github.com/guillaumevincent/karma-ievms-launcher).

Here are a few notes that I wanted to share:

- Two new babel "plugins" have been introduced in order to "transpile" correctly 
  - https://github.com/github/babel-plugin-transform-custom-element-classes
  - https://www.npmjs.com/package/babel-plugin-transform-es2015-classes

- The [webcomponentjs](https://github.com/webcomponents/webcomponentsjs) polyfills are being used for browsers that don't natively support the different Web component APIs, and you'll notice that this dependency is being directly downloaded from the GitHub repository. The latest version is not published on [npm](https://www.npmjs.com/package/webcomponents.js) and we're not using [bower](https://bower.io/). An issue has been opened to get more information on when this package will be available through npm.

- At the moment, nothing has been done concerning the Custom element [adoptedCallback](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements#Custom_element_methods) method, mostly for simplicity and also because this callback is not supported by the polyfill (see: https://github.com/webcomponents/custom-elements#known-bugs-and-limitations) 

- Concerning the tests:

  - The polyfills used, are (or must be) doing something to `HTMLElement` (or `Node`) because they cause a test that was working to break

    This is the specific [test](https://github.com/metal/metal.js/blob/master/packages/metal-dom/test/dom.js#L191-L199), and here are some of the error messages in different browsers

    ```
    Firefox: Firefox 53.0.0 (Mac OS X 10.12.0) dom manipulation should append node list to parent element FAILED
            Argument 1 of Node.appendChild does not implement interface Node.
    ```

    ```
    Edge:   Edge 14.14393.0 (Windows 10 0.0.0) dom manipulation should append node list to parent element FAILED
            Error: No such interface supported
    ```

    ```
    IE11:   IE 11.0.0 (Windows 7 0.0.0) dom manipulation should append node list to parent element FAILED
            HierarchyRequestError
    ```

- Concerning **IE10**:

  - I have not been able to run the tests in IE10 despite multiple attempts. The "browserified" bundle loaded by Karma, launches an error in IE10, concerning `Object.setPrototypeOf`.
  
  - The polyfill used do no support **IE10** either.

  - I am trying to find a way to "skip" the tests, as well as not loading the bundled polyfills for IE10 and lower, but have not yet found a way. - Any help is welcome

As usual your ideas and feedback concerning improvements are welcome.

Thanks!


