### PR TITLE
Issue/209

### DIFF
--- a/packages/metal-dom/src/domNamed.js
+++ b/packages/metal-dom/src/domNamed.js
@@ -340,7 +340,8 @@ export function hasClass(element, className) {
  * @private
  */
 function hasClassWithNative_(element, className) {
-	return element.classList.contains(className);
+	return className.indexOf(' ') === -1 &&
+		element.classList.contains(className);
 }
 
 /**
@@ -351,7 +352,8 @@ function hasClassWithNative_(element, className) {
  * @private
  */
 function hasClassWithoutNative_(element, className) {
-	return (` ${element.className} `).indexOf(` ${className} `) >= 0;
+	return (` ${element.className} `).indexOf(` ${className} `) >= 0 &&
+		className.split(' ').length === 1;
 }
 
 /**

--- a/packages/metal-dom/test/dom.js
+++ b/packages/metal-dom/test/dom.js
@@ -150,6 +150,16 @@ describe('dom', function() {
 			dom.toggleClasses(element, 'adipiscing elit lorem sit consectetur');
 			assert.strictEqual('ipsum dolor amet adipiscing elit consectetur', element.className);
 		});
+
+		it('should return false when checking if a classname with spaces exists', function() {
+			let el = document.createElement('div');
+			dom.addClasses(el, 'foo');
+			dom.addClasses(el, 'bar');
+			assert.strictEqual(dom.hasClass(el, 'foo'), true);
+			assert.strictEqual(dom.hasClass(el, 'bar'), true);
+			assert.strictEqual(dom.hasClass(el, 'foo bar'), false);
+			assert.strictEqual(dom.hasClass(el, 'bar foo'), false);
+		});
 	});
 
 	describe('contains', function() {


### PR DESCRIPTION
These commits solve the report described con #209, however, there are three things pending before finishing:

- I only have passed the tests on latest Chrome and Firefox (for Linux). Checking the MDN documentation I have found that DOMException is a common type of exception implemented by Chrome, Firefox, Edge and IE (links below), buy I have no information about Safari implementation.
- I thought about another way of implementing hasClassWithNative_, and it's returning false if the given className has an space (same than hasClassWithoutNative_). Personally I prefer relying on the native implementation and then catching the error, but I am not sure what kind of behaviour you prefer.
- For checking the coverage, I temporary inverted the "has native implementation", because I have no browser without a native implementation. Maybe you have some kind of browserstack for the testing.

MDN DOMException docs: https://developer.mozilla.org/en-US/docs/Web/API/DOMException
MSDN DOMException docs: https://msdn.microsoft.com/es-es/library/ff974354(v=vs.85).aspx