### PR TITLE
Bug: elementClasses not being passed to child component

### DIFF
--- a/packages/metal-incremental-dom/src/render/render.js
+++ b/packages/metal-incremental-dom/src/render/render.js
@@ -463,6 +463,18 @@ export function renderFunction(renderer, fnOrCtor, opt_dataOrElement, opt_parent
 function renderSubComponent_(tagOrCtor, config, opt_owner) {
 	const parent = getComponentBeingRendered();
 	const owner = opt_owner || parent;
+
+	const parentData = getData(parent);
+	const parentConfig = parentData.config;
+	if (!parentData.rootElementReached && parentConfig && isString(parentConfig.elementClasses)) {
+		let currentClasses = '';
+		if (isString(config.elementClasses)) {
+			currentClasses = `${config.elementClasses} `;
+		}
+
+		config.elementClasses = currentClasses + parentConfig.elementClasses;
+	}
+
 	const comp = getSubComponent_(tagOrCtor, config, owner);
 	updateContext_(comp, parent);
 
@@ -470,7 +482,6 @@ function renderSubComponent_(tagOrCtor, config, opt_owner) {
 	data.parent = parent;
 	data.owner = owner;
 
-	const parentData = getData(parent);
 	getChildComponents_(parentData).push(comp);
 	if (!config.key && !parentData.rootElementReached) {
 		config.key = parentData.config.key;

--- a/packages/metal-jsx/test/JSXComponent.js
+++ b/packages/metal-jsx/test/JSXComponent.js
@@ -306,6 +306,101 @@ describe('JSXComponent', function() {
 				done();
 			});
 		});
+
+		it('component.element and child.element should be the same', function() {
+			class ChildComponent extends JSXComponent {
+				render() {
+					return <div class="child"></div>;
+				}
+			}
+
+			class ParentComponent extends JSXComponent {
+				render() {
+					return <ChildComponent ref="child" />;
+				}
+			}
+
+			component = new ParentComponent();
+			var child = component.refs.child;
+			assert.strictEqual(component.element, child.element);
+		});
+
+		it('should receive elementClasses from parent component', function() {
+			class ChildComponent extends JSXComponent {
+				render() {
+					return <div class="child"></div>;
+				}
+			}
+
+			class ParentComponent extends JSXComponent {
+				render() {
+					return <ChildComponent />;
+				}
+			}
+
+			component = new ParentComponent({elementClasses: 'foo'});
+			assert.ok(dom.hasClass(component.element, 'child'));
+			assert.ok(dom.hasClass(component.element, 'foo'));
+		});
+
+		it('should not apply undefined class', function() {
+			class ChildComponent extends JSXComponent {
+				render() {
+					return <div class="child"></div>;
+				}
+			}
+
+			class ParentComponent extends JSXComponent {
+				render() {
+					return <ChildComponent />;
+				}
+			}
+
+			component = new ParentComponent({elementClasses: undefined});
+			assert.strictEqual(component.element.className, 'child');
+		});
+
+		it('should not create duplicate classes', function() {
+			class ChildComponent extends JSXComponent {
+				render() {
+					return <div class="child"></div>;
+				}
+			}
+
+			class ParentComponent extends JSXComponent {
+				render() {
+					return <ChildComponent />;
+				}
+			}
+
+			component = new ParentComponent({elementClasses: 'child'});
+			assert.strictEqual(component.element.className, 'child');
+		});
+
+		it('should pass elementClasses through higher order components', function() {
+			class GrandChildComponent extends JSXComponent {
+				render() {
+					return <div class="grandchild"></div>;
+				}
+			}
+
+			class ChildComponent extends JSXComponent {
+				render() {
+					return <GrandChildComponent elementClasses="child" />;
+				}
+			}
+
+			class ParentComponent extends JSXComponent {
+				render() {
+					return <ChildComponent elementClasses="parent" />;
+				}
+			}
+
+			component = new ParentComponent({elementClasses: 'foo'});
+			assert.ok(dom.hasClass(component.element, 'child'));
+			assert.ok(dom.hasClass(component.element, 'parent'));
+			assert.ok(dom.hasClass(component.element, 'grandchild'));
+		});
 	});
 
 	describe('shouldUpdate', function() {

--- a/packages/metal-soy/test/Soy.js
+++ b/packages/metal-soy/test/Soy.js
@@ -7,6 +7,7 @@ import { ComputedData as ComputedDataComponent } from './assets/ComputedData.soy
 import { ExternalTemplate as ExternalTemplateComponent } from './assets/ExternalTemplate.soy.js';
 import { Functions as FunctionsComponent } from './assets/Functions.soy.js';
 import { HelloWorld as HelloWorldComponent, templates as helloWorldTemplates } from './assets/HelloWorld.soy.js';
+import { HigherOrder as HigherOrderComponent } from './assets/HigherOrder.soy.js';
 import { HtmlContent as HtmlContentComponent } from './assets/HtmlContent.soy.js';
 import { IJData as IJDataComponent } from './assets/IJData.soy.js';
 import { Nested as NestedComponent } from './assets/Nested.soy.js';
@@ -15,6 +16,7 @@ import { NestedLevels as NestedLevelsComponent } from './assets/NestedLevels.soy
 import { NestedMultiple as NestedMultipleComponent } from './assets/NestedMultiple.soy.js';
 import { NestedNoData as NestedNoDataComponent } from './assets/NestedNoData.soy.js';
 import { TemplateData as TemplateDataComponent } from './assets/TemplateData.soy.js';
+
 import Soy from '../src/Soy';
 
 describe('Soy', function() {
@@ -59,6 +61,12 @@ describe('Soy', function() {
 				assert.strictEqual('Hello Bar!', comp.element.textContent);
 				done();
 			});
+		});
+
+		it('should pass elementClasses for higher order components', function() {
+			comp = new HigherOrderComponent({elementClasses: 'parent'});
+			assert.ok(dom.hasClass(comp.element, 'child'));
+			assert.ok(dom.hasClass(comp.element, 'parent'));
 		});
 
 		describe('Should Update', function() {

--- a/packages/metal-soy/test/assets/HigherOrder.soy
+++ b/packages/metal-soy/test/assets/HigherOrder.soy
@@ -1,0 +1,16 @@
+{namespace HigherOrder}
+
+
+/**
+ *
+ */
+{template .render}
+	{call .component /}
+{/template}
+
+/**
+ *
+ */
+{template .component}
+	<div class="child"></div>
+{/template}


### PR DESCRIPTION
Hey, wanted to make sure that everyone agrees this is an issue before I look into fixing it.

I would expect that if a component returns another component at the top level, it should pass `elementClasses` down to that child component.

Reference to [higher-order-components](https://facebook.github.io/react/docs/higher-order-components.html)