### PR TITLE
Adds `writeOnce` method to state Config utils

### DIFF
--- a/packages/metal-state/src/Config.js
+++ b/packages/metal-state/src/Config.js
@@ -189,6 +189,17 @@ const Config = {
 		return mergeConfig(this, {
 			valueFn
 		});
+	},
+
+	/**
+	 * Adds the `writeOnce` flag to the `State` configuration.
+	 * @param {boolean} writeOnce Flag to set "writeOnce" to. False by default.
+	 * @return {!Object} `State` configuration object.
+	 */
+	writeOnce(writeOnce = false) {
+		return mergeConfig(this, {
+			writeOnce
+		});
 	}
 };
 

--- a/packages/metal-state/test/Config.js
+++ b/packages/metal-state/test/Config.js
@@ -60,6 +60,25 @@ describe('Config', function() {
 		}, config.config);
 	});
 
+	it('should return config with "writeOnce" flag set to false by default', function() {
+		var config = Config.writeOnce();
+		assert.ok(core.isObject(config));
+
+		var expected = {
+			writeOnce: false
+		};
+		assert.deepEqual(expected, config.config);
+	});
+
+	it('should return config with "writeOnce" flag set to the given vaue', function() {
+		var writeOnce = true;
+		var config = Config.writeOnce(writeOnce);
+		assert.ok(core.isObject(config));
+		assert.deepEqual({
+			writeOnce
+		}, config.config);
+	});
+
 	it('should return config with specified "setter"', function() {
 		var setter = () => {
 		};


### PR DESCRIPTION
There is a `writeOnce` property that can be set for state configuration that makes a property behave as read only, but our `Config` util doesn't have a shorthand method for it.