### PR TITLE
Some changes on validators

### DIFF
--- a/packages/metal-state/src/validators.js
+++ b/packages/metal-state/src/validators.js
@@ -29,7 +29,7 @@ const validators = {
 	 */
 	arrayOf: function(validator) {
 		const argsResult = validators.func(validator);
-		if(isInvalid(argsResult)){
+		if (isInvalid(argsResult)) {
 			return argsResult;
 		}
 		return maybe((value, name, context) => {
@@ -64,7 +64,7 @@ const validators = {
 	 */
 	objectOf: function(validator) {
 		const validatorResult = validators.func(validator);
-		if(isInvalid(validatorResult)){
+		if (isInvalid(validatorResult)) {
 			return validatorResult;
 		}
 		return maybe((value, name, context) => {
@@ -136,13 +136,13 @@ const validators = {
 	 * @return {!function()}
 	 */
 	shapeOf: function(shape) {
+		const shapeResult = validators.object(shape);
+		if (isInvalid(shapeResult)) {
+			return shapeResult;
+		}
 		return maybe((value, name, context) => {
-			const shapeResult = validators.object(shape, name, context);
 			const valueResult = validators.object(value, name, context);
-			if (isInvalid(shapeResult)) {
-				return shapeResult;
-			}
-			if(isInvalid(valueResult)) {
+			if (isInvalid(valueResult)) {
 				return valueResult;
 			}
 			for (let key in shape) {
@@ -206,7 +206,7 @@ function composeError(error, name, context) {
 		: '';
 	return new Error(
 		`Invalid state passed to '${name}'.` +
-	    	` ${error} Passed to '${compName}'. ${location}`
+			` ${error} Passed to '${compName}'. ${location}`
 	);
 }
 
@@ -264,7 +264,9 @@ function validateArrayItems(validator, value, name, context) {
 	for (let i = 0; i < value.length; i++) {
 		if (isInvalid(validator(value[i], name, context))) {
 			let itemValidatorError = validator(value[i], name, context);
-			let errorMessage = `Validator for ${name}[${i}] says: "${itemValidatorError}"`;
+			let errorMessage = `Validator for ${name}[${i}] says: "${
+				itemValidatorError
+			}"`;
 			return composeError(errorMessage, name, context);
 		}
 	}

--- a/packages/metal-state/src/validators.js
+++ b/packages/metal-state/src/validators.js
@@ -2,11 +2,9 @@
 
 import {getFunctionName, isDefAndNotNull} from 'metal';
 
-const ERROR_ARRAY_OF_TYPE = 'Expected an array of single type.';
 const ERROR_OBJECT_OF_TYPE = 'Expected object of one type.';
 const ERROR_ONE_OF = 'Expected one of the following values:';
 const ERROR_ONE_OF_TYPE = 'Expected one of given types.';
-const ERROR_SHAPE_OF = 'Expected object with a specific shape.';
 
 /**
  * Provides access to various type validators that will return an

--- a/packages/metal-state/src/validators.js
+++ b/packages/metal-state/src/validators.js
@@ -199,8 +199,8 @@ function composeError(error, name, context) {
 		? `Check render method of '${parentName}'.`
 		: '';
 	return new Error(
-		`Warning: Invalid state passed to '${name}'. ` +
-			`${error} Passed to '${compName}'. ${location}`
+		`Invalid state passed to '${name}'.` +
+	    	` ${error} Passed to '${compName}'. ${location}`
 	);
 }
 

--- a/packages/metal-state/src/validators.js
+++ b/packages/metal-state/src/validators.js
@@ -157,7 +157,7 @@ const validators = {
 						(required && !isDefAndNotNull(value[key])) ||
 						isInvalid(validator(value[key]))
 					) {
-						return validator(value[key], name + '.' + key, context);
+						return validator(value[key], `${name}.${key}`, context);
 					}
 				}
 			}

--- a/packages/metal-state/src/validators.js
+++ b/packages/metal-state/src/validators.js
@@ -28,6 +28,10 @@ const validators = {
 	 * @return {!function()}
 	 */
 	arrayOf: function(validator) {
+		const argsResult = validators.func(validator);
+		if(isInvalid(argsResult)){
+			return argsResult;
+		}
 		return maybe((value, name, context) => {
 			const result = validators.array(value, name, context);
 			if (isInvalid(result)) {
@@ -59,6 +63,10 @@ const validators = {
 	 * @return {!function()}
 	 */
 	objectOf: function(validator) {
+		const validatorResult = validators.func(validator);
+		if(isInvalid(validatorResult)){
+			return validatorResult;
+		}
 		return maybe((value, name, context) => {
 			for (let key in value) {
 				if (isInvalid(validator(value[key]))) {

--- a/packages/metal-state/src/validators.js
+++ b/packages/metal-state/src/validators.js
@@ -131,11 +131,14 @@ const validators = {
 	 */
 	shapeOf: function(shape) {
 		return maybe((value, name, context) => {
-			const result = validators.object(shape, name, context);
-			if (isInvalid(result)) {
-				return result;
+			const shapeResult = validators.object(shape, name, context);
+			const valueResult = validators.object(value, name, context);
+			if (isInvalid(shapeResult)) {
+				return shapeResult;
 			}
-
+			if(isInvalid(valueResult)) {
+				return valueResult;
+			}
 			for (let key in shape) {
 				if (Object.prototype.hasOwnProperty.call(shape, key)) {
 					let validator = shape[key];
@@ -148,7 +151,7 @@ const validators = {
 						(required && !isDefAndNotNull(value[key])) ||
 						isInvalid(validator(value[key]))
 					) {
-						return composeError(ERROR_SHAPE_OF, name, context);
+						return validator(value[key], name + '.' + key, context);
 					}
 				}
 			}

--- a/packages/metal-state/src/validators.js
+++ b/packages/metal-state/src/validators.js
@@ -257,7 +257,9 @@ function maybe(typeValidator) {
 function validateArrayItems(validator, value, name, context) {
 	for (let i = 0; i < value.length; i++) {
 		if (isInvalid(validator(value[i], name, context))) {
-			return composeError(ERROR_ARRAY_OF_TYPE, name, context);
+			let itemValidatorError = validator(value[i], name, context);
+			let errorMessage = `Validator for ${name}[${i}] says: "${itemValidatorError}"`;
+			return composeError(errorMessage, name, context);
 		}
 	}
 	return true;

--- a/packages/metal-state/test/Config.js
+++ b/packages/metal-state/test/Config.js
@@ -143,32 +143,32 @@ describe('Config', function() {
 		assert.ok(config.config.validator(['one']) instanceof Error);
 	});
 
-	it('should return config with "arrayOf" validator inheriting "shapeOf" and "oneOf" from "validators"', function(){
-		var shape = {
+	it('should return config with "arrayOf" validator inheriting "shapeOf" and "oneOf" from "validators"', function() {
+		let shape = {
 			one: Config.bool().value(false),
 			two: Config.string(),
-			three: Config.oneOf([
-				'propOne',
-				'propTwo',
-				'propThree'
-			]).value('propOne'),
-			four: Config.number().required()
+			three: Config.oneOf(['propOne', 'propTwo', 'propThree']).value('propOne'),
+			four: Config.number().required(),
 		};
-		var configShape = Config.arrayOf(Config.shapeOf(shape));
+		let configShape = Config.arrayOf(Config.shapeOf(shape));
 		assert.ok(core.isObject(configShape));
 		assert.ok(core.isFunction(configShape.config.validator));
-		assert.ok(configShape.config.validator({
-			one: false,
-			two: 30,
-			three: 'anything',
-		}) instanceof Error);
+		assert.ok(
+			configShape.config.validator({
+				one: false,
+				two: 30,
+				three: 'anything',
+			}) instanceof Error
+		);
 		assert.ok(configShape.config.validator([1, 2]) instanceof Error);
-		assert.ok(configShape.config.validator({
-			one: false,
-			two: 'is String!',
-			three: 'propOne',
-			four: 30
-		}));
+		assert.ok(
+			configShape.config.validator({
+				one: false,
+				two: 'is String!',
+				three: 'propOne',
+				four: 30,
+			})
+		);
 	});
 
 	it('should return config with "bool" validator from "validators"', function() {

--- a/packages/metal-state/test/Config.js
+++ b/packages/metal-state/test/Config.js
@@ -143,6 +143,34 @@ describe('Config', function() {
 		assert.ok(config.config.validator(['one']) instanceof Error);
 	});
 
+	it('should return config with "arrayOf" validator inheriting "shapeOf" and "oneOf" from "validators"', function(){
+		var shape = {
+			one: Config.bool().value(false),
+			two: Config.string(),
+			three: Config.oneOf([
+				'propOne',
+				'propTwo',
+				'propThree'
+			]).value('propOne'),
+			four: Config.number().required()
+		};
+		var configShape = Config.arrayOf(Config.shapeOf(shape));
+		assert.ok(core.isObject(configShape));
+		assert.ok(core.isFunction(configShape.config.validator));
+		assert.ok(configShape.config.validator({
+			one: false,
+			two: 30,
+			three: 'anything',
+		}) instanceof Error);
+		assert.ok(configShape.config.validator([1, 2]) instanceof Error);
+		assert.ok(configShape.config.validator({
+			one: false,
+			two: 'is String!',
+			three: 'propOne',
+			four: 30
+		}));
+	});
+
 	it('should return config with "bool" validator from "validators"', function() {
 		let config = Config.bool();
 		assert.ok(core.isObject(config));

--- a/packages/metal-state/test/validators.js
+++ b/packages/metal-state/test/validators.js
@@ -55,6 +55,12 @@ describe('validators', function() {
 		assert.isTrue(validator(function() {}));
 	});
 
+	it('should fail if an argument is not supplied to arrayOf', function() {
+		const wrongArrayOf = validators.arrayOf(2);
+
+		assert.ok(wrongArrayOf instanceof Error);
+	});
+
 	it('should validate an array of a single type', function() {
 		const arrayOfNumbers = validators.arrayOf(validators.number);
 
@@ -121,6 +127,12 @@ describe('validators', function() {
 		});
 
 		assert.ok(validator({}) instanceof Error);
+	});
+
+	it('should fail if an argument is not supplied to objectOf', function() {
+		const wrongObjectOf = validators.objectOf(2);
+
+		assert.ok(wrongObjectOf instanceof Error);
 	});
 
 	it('should validate an object with certain types of values', function() {

--- a/packages/metal-state/test/validators.js
+++ b/packages/metal-state/test/validators.js
@@ -218,7 +218,8 @@ describe('validators', function() {
 
 	it('should fail if an object is not supplied to shape', function() {
 		const validator = validators.shapeOf(1);
-		assert.ok(validator({}) instanceof Error);
+
+		assert.ok(validator instanceof Error);
 	});
 
 	it('should emit warning message', function() {

--- a/packages/metal-state/test/validators.js
+++ b/packages/metal-state/test/validators.js
@@ -215,7 +215,7 @@ describe('validators', function() {
 		const PARENT_COMPONENT_NAME = 'parentComponent';
 
 		const ERROR_MESSAGE =
-			`Error: Warning: Invalid state passed to '${NAME}'. ` +
+			`Error: Invalid state passed to '${NAME}'. ` +
 			`Expected type 'string', but received type 'number'. ` +
 			`Passed to '${COMPONENT_NAME}'. Check render ` +
 			`method of '${PARENT_COMPONENT_NAME}'.`;


### PR DESCRIPTION
## shapeOf:

Instead returns a simple message containing a constraint in a shape validation, now returns an validation error that property in shape returns.

If shapeOf catches a error, `validator()` function can be called returning a error that others validators inside shapeOf have returned.

Example: 

```
Error: Invalid state passed to 'icon.a'. Expected type 'object', but received type 'number'. Passed to 'ClayButton’.
```

## arrayOf:
	
Instead return a simple constraint now returns a error showing that a index in array validator returns. 

I’ve modified `validateArrayItems()` function that emits arrayOf error message, this function now returns a validator call in the same way of shapeOf and i’ve appended a string for show the error message on the error’s index. 

Example:

```
Error: Invalid state passed to 'values'. Validator for values[2] says: "Error: Invalid state passed to 'values'. Expected type 'string', but received type 'number'. Passed to 'ClayDropdown'. " Passed to 'ClayDropdown'. 
```

### 'Warning':

I've removed warning string fragments to compose a message more clean instead of:

```
Warning: Error: Warning: Invalid state passed to 'label'. Expected type 'string', but received type 'number'. Passed to 'ClayBadge'. 
```
After changes will be like:
```
Error: Invalid state passed to 'label'. Expected type 'string', but received type 'number'. Passed to 'ClayBadge'. 
```

### Some fixes:

On solving these problems, i’ve noticed that shapeOf validation doesn’t verify `shape`(argument of function), causing that developer only receive a feedback of bad using this function on instantiate a new instance of metal. I had solved these problem validating arguments before executing them like, but i think this is not appropriated handling for devs.

I’m searching for enhance this handling. What do you think guys? 