### PR TITLE
Fixing test:coverage script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "precommit": "lint-staged",
     "prettier": "prettier-eslint 'packages/metal*/{src,test}/**/*.js'",
     "test": "gulp soy && karma start && npm run test:isomorphic",
-    "test:coverage": "gulp soy karma start karma-coverage.conf.js",
+    "test:coverage": "gulp soy && karma start karma-coverage.conf.js",
     "test:isomorphic": "gulp soy:isomorphic && mocha packages/metal-isomorphic/test/isomorphic.js --compilers js:babel-core/register",
     "test:saucelabs": "gulp soy && karma start karma-saucelabs.conf.js"
   },


### PR DESCRIPTION
When i running test:coverage script i've get:
<img width="748" alt="screen shot 2017-11-23 at 15 41 59" src="https://user-images.githubusercontent.com/7663513/33186054-87dc46e0-d065-11e7-8b59-c9423336887f.png">

This problem is caused by a missing ``&&`` in script on package.json to compile soy and execute karma later. 
<img width="867" alt="screen shot 2017-11-23 at 15 44 11" src="https://user-images.githubusercontent.com/7663513/33186052-87c263a6-d065-11e7-9314-7a4de797e019.png">

