### PR TITLE
Add links to metaljs.com from package readme files

### DIFF
--- a/packages/metal-assertions/README.md
+++ b/packages/metal-assertions/README.md
@@ -1,3 +1,5 @@
 # metal-assertions
 
 A collection of assertion methods for metal
+
+See [https://metaljs.com/](https://metaljs.com/) for documentation.

--- a/packages/metal-component/README.md
+++ b/packages/metal-component/README.md
@@ -1,3 +1,5 @@
 # metal-component
 
 A component class for Metal.js.
+
+See [https://metaljs.com/](https://metaljs.com/) for documentation.

--- a/packages/metal-dom/README.md
+++ b/packages/metal-dom/README.md
@@ -1,3 +1,5 @@
 # metal-dom
 
 A collection of utility functions for handling dom elements.
+
+See [https://metaljs.com/](https://metaljs.com/) for documentation.

--- a/packages/metal-events/README.md
+++ b/packages/metal-events/README.md
@@ -1,3 +1,5 @@
 # metal-events
 
 Classes responsible for emitting and listening to events.
+
+See [https://metaljs.com/](https://metaljs.com/) for documentation.

--- a/packages/metal-incremental-dom/README.md
+++ b/packages/metal-incremental-dom/README.md
@@ -1,3 +1,5 @@
 # metal-incremental-dom
 
 A Component renderer for templates compiled to incremental dom.
+
+See [https://metaljs.com/](https://metaljs.com/) for documentation.

--- a/packages/metal-jsx/README.md
+++ b/packages/metal-jsx/README.md
@@ -1,3 +1,5 @@
 # metal-jsx
 
 A JSX templates renderer to be used with Metal.js's Component class.
+
+See [https://metaljs.com/docs/guides/jsx-components.html](https://metaljs.com/docs/guides/jsx-components.html) for documentation.

--- a/packages/metal-soy-bundle/README.md
+++ b/packages/metal-soy-bundle/README.md
@@ -4,3 +4,5 @@ metal-soy-bundle
 A bundle containing all the closure dependencies required by soy files compiled to incremental-dom.
 
 Note that this bundle was built by hand, and some features were deliberately removed to make the resulting bundle smaller, like escaping (which shouldn't be necessary for incremental dom anyway) and bidi directives (which will be added back soon).
+
+See [https://metaljs.com/](https://metaljs.com/) for documentation.

--- a/packages/metal-soy/README.md
+++ b/packages/metal-soy/README.md
@@ -1,3 +1,5 @@
 # metal-soy
 
 A soy templates renderer to be used with Metal.js's Component class.
+
+See [https://metaljs.com/docs/guides/soy-components.html](https://metaljs.com/docs/guides/soy-components.html) for documentation.

--- a/packages/metal-state/README.md
+++ b/packages/metal-state/README.md
@@ -1,3 +1,5 @@
 # metal-state
 
 A class that adds support for watchable, configurable state.
+
+See [https://metaljs.com/docs/guides/state.html](https://metaljs.com/docs/guides/state.html) for documentation.

--- a/packages/metal/README.md
+++ b/packages/metal/README.md
@@ -1,3 +1,5 @@
 # metal
 
 Core functions from Metal.js, with utilities for dealing with arrays, objects and others.
+
+See [https://metaljs.com/](https://metaljs.com/) for documentation.


### PR DESCRIPTION
Adds a link to metaljs.com from the individual package's README.md files.

When there is a particular page that is applicable to the package in question, it is linked to, otherwise the landing page is linked to.