### PR TITLE
No longer use global setImmediate function due to performance issues

### DIFF
--- a/packages/metal/src/async/async.js
+++ b/packages/metal/src/async/async.js
@@ -101,15 +101,6 @@ async.nextTick = function(callback, context) {
 		cb = callback.bind(context);
 	}
 	cb = async.nextTick.wrapCallback_(cb);
-	// Introduced and currently only supported by IE10.
-	// Verify if variable is defined on the current runtime (i.e., node, browser).
-	// Can't use typeof enclosed in a function (such as core.isFunction) or an
-	// exception will be thrown when the function is called on an environment
-	// where the variable is undefined.
-	if (typeof setImmediate === 'function') {
-		setImmediate(cb);
-		return;
-	}
 	// Look for and cache the custom fallback version of setImmediate.
 	if (!async.nextTick.setImmediate_) {
 		// eslint-disable-next-line


### PR DESCRIPTION
## async.nextTick

Metal core currently provides an async module which has been brought over from google closure library, one of the most used methods from that module is `async.nextTick`. This method makes use of the browser’s `setImmediate` function if it is defined (currently only IE10+/Edge have a native implementation).

Because most browsers do not have `setImmediate` defined, the async module provides a fallback for this functionality. In addition, commonly used babel presets will automatically provide a polyfill from core-js. If the polyfill is defined, it will win over the fallback.

The problem is that the polyfill from core-js is _**significantly**_ slower than the fallback provided by google closure. In addition, the `setImmediate` implementation in IE has [known issues](https://connect.microsoft.com/IE/feedback/details/801823/setimmediate-and-messagechannel-are-broken-in-ie10). This means the only reliable native implementation is in Edge.

Due to these issues, closure library has introduced a change to their `nextTick` function so that it only uses the globally defined `setImmediate` function in Edge, or if the global function is an instance of their MockClock utility (which we do not provide in Metal).

My proposal is to never use the globally defined `setImmediate` method in Metal, and to always use the fallback provided by `async`. That way we know we are using an optimized solution, and it is consistent across all browsers and environments.

## Metrics

My test case consisted of a table with 10,000 rows, and another with just 1000 rows. Each row being a sub component of the parent.

In both scenarios, **the time it took to update the rows with new data was reduced by ~48%** by no longer using the polyfill on Chrome.

### 10,000 row update with `setImmediate` polyfill

<img width="504" alt="screen shot 2018-01-10 at 12 13 50 pm" src="https://user-images.githubusercontent.com/2466445/34794604-1155ccde-f604-11e7-840d-0ce4dbfe49c2.png">

### 10,000 row update with closure library's fallback

<img width="425" alt="screen shot 2018-01-10 at 12 16 50 pm" src="https://user-images.githubusercontent.com/2466445/34794613-17cda32a-f604-11e7-8c22-24e4c4500afd.png">
