### PR TITLE
Use globally defined setImmediate on server side for test suites like jest that have mock timers

### DIFF
--- a/packages/metal/src/async/async.js
+++ b/packages/metal/src/async/async.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+import {isServerSide} from 'metal';
+
 const async = {};
 
 /**
@@ -105,8 +107,7 @@ async.nextTick = function(callback, context) {
 	if (!async.nextTick.setImmediate_) {
 		if (
 			typeof setImmediate === 'function' &&
-			typeof process !== 'undefined' &&
-			!process.browser
+			isServerSide({checkEnv: false})
 		) {
 			async.nextTick.setImmediate_ = setImmediate;
 		} else {

--- a/packages/metal/src/async/async.js
+++ b/packages/metal/src/async/async.js
@@ -103,8 +103,16 @@ async.nextTick = function(callback, context) {
 	cb = async.nextTick.wrapCallback_(cb);
 	// Look for and cache the custom fallback version of setImmediate.
 	if (!async.nextTick.setImmediate_) {
-		// eslint-disable-next-line
-		async.nextTick.setImmediate_ = async.nextTick.getSetImmediateEmulator_();
+		if (
+			typeof setImmediate === 'function' &&
+			typeof process !== 'undefined' &&
+			!process.browser
+		) {
+			async.nextTick.setImmediate_ = setImmediate;
+		} else {
+			// eslint-disable-next-line
+			async.nextTick.setImmediate_ = async.nextTick.getSetImmediateEmulator_();
+		}
 	}
 	async.nextTick.setImmediate_(cb);
 };

--- a/packages/metal/src/coreNamed.js
+++ b/packages/metal/src/coreNamed.js
@@ -295,15 +295,18 @@ export function isString(val) {
  * Sets to true if running inside Node.js environment with extra check for
  * `process.browser` to skip Karma runner environment. Karma environment has
  * `process` defined even though it runs on the browser.
+ * @param {?Object} options Contains `checkEnv` property which if true, checks
+ * the NODE_ENV variable. If NODE_ENV equals 'test', the function returns false.
  * @return {boolean}
  */
-export function isServerSide() {
-	return (
-		typeof process !== 'undefined' &&
-		typeof process.env !== 'undefined' &&
-		process.env.NODE_ENV !== 'test' &&
-		!process.browser
-	);
+export function isServerSide(options = {checkEnv: true}) {
+	let serverSide = typeof process !== 'undefined' && !process.browser;
+	if (serverSide && options.checkEnv) {
+		serverSide =
+			typeof process.env !== 'undefined' &&
+			process.env.NODE_ENV !== 'test';
+	}
+	return serverSide;
 }
 
 /**

--- a/packages/metal/test/core.js
+++ b/packages/metal/test/core.js
@@ -257,6 +257,51 @@ describe('core', function() {
 		});
 	});
 
+	describe('isServerSide', function() {
+		const originalBrowser = process.browser;
+		const originalEnv = process.env;
+
+		beforeEach(function() {
+			process.env = {
+				NODE_ENV: '',
+			};
+			process.browser = true;
+		});
+
+		afterEach(function() {
+			process.env = originalEnv;
+			process.browser = originalBrowser;
+		});
+
+		it('should return false when process global exists and browser property is true', function() {
+			assert.ok(!core.isServerSide());
+		});
+
+		it('should return true when process global exists and browser property is false', function() {
+			process.browser = false;
+
+			assert.ok(core.isServerSide());
+		});
+
+		it('should return false when NODE_ENV is set to "test"', function() {
+			process.browser = false;
+			process.env.NODE_ENV = 'test';
+
+			assert.ok(!core.isServerSide());
+		});
+
+		it('should skip NODE_ENV check when options.checkEnv is set to false', function() {
+			process.browser = false;
+			process.env.NODE_ENV = 'test';
+
+			assert.ok(
+				core.isServerSide({
+					checkEnv: false,
+				})
+			);
+		});
+	});
+
 	describe('Null Function', function() {
 		it('should not return anything', function() {
 			assert.strictEqual(undefined, core.nullFunction());


### PR DESCRIPTION
Jest leverages Node's `setImmediate` function with it's mock timers. After updating `metal-clay-components` to metal 2.16.0, there were a few test failures due to this.

My proposal is that we use the globally defined `setImmediate` only when it's defined on the server.

The reason for not using Metal's `isServerSide` method here, is that it also checks if the `NODE_ENV` variable is equal to "test", which is the case in `metal-clay-components` and other projects which use jest.