### PR TITLE
Fix syntax error in tutorial components page

### DIFF
--- a/packages/metaljs.com/src/pages/docs/tutorials/tutorial-todo-jsx/components.md
+++ b/packages/metaljs.com/src/pages/docs/tutorials/tutorial-todo-jsx/components.md
@@ -24,9 +24,11 @@ creates the HTML you see in the demo page:
 
 ```text/jsx
 class TodoApp extends JSXComponent {
-	return (
-		<div>Hello, World</div>
-	);
+	render() {
+		return (
+			<div>Hello, World</div>
+		);
+	}
 }
 ```
 


### PR DESCRIPTION
Someone forgot `render` 😅 