### PR TITLE
Move the `a` tag from the block to inline in HTMLParser | Fixes #371

### DIFF
--- a/packages/metal-incremental-dom/src/html/HTMLParser.js
+++ b/packages/metal-incremental-dom/src/html/HTMLParser.js
@@ -97,12 +97,12 @@ var empty = makeMap(
 
 // Block Elements - HTML 5
 var block = makeMap(
-	'a,address,article,applet,aside,audio,blockquote,button,canvas,center,dd,del,dir,div,dl,dt,fieldset,figcaption,figure,footer,form,frameset,h1,h2,h3,h4,h5,h6,header,hgroup,hr,iframe,ins,isindex,li,map,menu,noframes,noscript,object,ol,output,p,pre,section,script,table,tbody,td,tfoot,th,thead,tr,ul,video'
+	'address,article,applet,aside,audio,blockquote,button,canvas,center,dd,del,dir,div,dl,dt,fieldset,figcaption,figure,footer,form,frameset,h1,h2,h3,h4,h5,h6,header,hgroup,hr,iframe,ins,isindex,li,map,menu,noframes,noscript,object,ol,output,p,pre,section,script,table,tbody,td,tfoot,th,thead,tr,ul,video'
 );
 
 // Inline Elements - HTML 5
 var inline = makeMap(
-	'abbr,acronym,applet,b,basefont,bdo,big,br,button,cite,code,del,dfn,em,font,i,iframe,img,input,ins,kbd,label,map,object,q,s,samp,script,select,small,span,strike,strong,sub,sup,textarea,tt,u,var'
+	'a,abbr,acronym,applet,b,basefont,bdo,big,br,button,cite,code,del,dfn,em,font,i,iframe,img,input,ins,kbd,label,map,object,q,s,samp,script,select,small,span,strike,strong,sub,sup,textarea,tt,u,var'
 );
 
 // Elements that you can, intentionally, leave open

--- a/packages/metal-incremental-dom/src/html/HTMLParser.js
+++ b/packages/metal-incremental-dom/src/html/HTMLParser.js
@@ -200,14 +200,15 @@ var HTMLParser = function(html, handler) {
 		tagName = tagName.toLowerCase();
 
 		if (block[tagName]) {
-			// Close last tag if it's inline, except if it's a "span" (since people
+			// Close last tag if it's inline, except if it's a "span" and "a" (since people
 			// usually add anything they want to spans, and browsers allow it).
-			// Note: this exception for "span" was added manually (i.e. it's not
+			// Note: this exception for "span" and "a" was added manually (i.e. it's not
 			// present in the original code).
 			while (
 				stack.last() &&
 				inline[stack.last()] &&
-				stack.last() !== 'span'
+				stack.last() !== 'span' &&
+				stack.last() !== 'a'
 			) {
 				parseEndTag('', stack.last());
 			}

--- a/packages/metal-incremental-dom/test/html/HTML2IncDom.js
+++ b/packages/metal-incremental-dom/test/html/HTML2IncDom.js
@@ -17,6 +17,49 @@ describe('HTML2IncDom', function() {
 		assert.strictEqual(htmlStr, element.innerHTML);
 	});
 
+	it('should render a link element with inline elements inside via incremental dom', function() {
+		let element = document.createElement('div');
+		let htmlStr = '<a href="http://foo.com"><strong><b>Foo</b></strong></a>';
+		IncrementalDOM.patch(element, () => HTML2IncDom.run(htmlStr));
+
+		assert.strictEqual(htmlStr, element.innerHTML);
+	});
+
+	it('should render a link element within inline elements via incremental dom', function() {
+		let element = document.createElement('div');
+		let htmlStr = '<strong><b><a href="http://foo.com">Foo</a></b></strong>';
+		IncrementalDOM.patch(element, () => HTML2IncDom.run(htmlStr));
+
+		assert.strictEqual(htmlStr, element.innerHTML);
+	});
+
+	it('should render a link element inside inline and block elements via incremental dom', function() {
+		let element = document.createElement('div');
+		let htmlStr =
+			'<p><strong><b><a href="http://foo.com">Foo</a></b></strong></p>';
+		IncrementalDOM.patch(element, () => HTML2IncDom.run(htmlStr));
+
+		assert.strictEqual(htmlStr, element.innerHTML);
+	});
+
+	it('should render a link element with inline elements inside and inside a block element via incremental dom', function() {
+		let element = document.createElement('div');
+		let htmlStr =
+			'<div><a href="http://foo.com"><strong><b>Foo</b></strong></a></div>';
+		IncrementalDOM.patch(element, () => HTML2IncDom.run(htmlStr));
+
+		assert.strictEqual(htmlStr, element.innerHTML);
+	});
+
+	it('should render a link element with block elements inside via incremental dom', function() {
+		let element = document.createElement('div');
+		let htmlStr =
+			'<a href="http://foo.com"><div><strong><b>Foo</b></strong></div></a>';
+		IncrementalDOM.patch(element, () => HTML2IncDom.run(htmlStr));
+
+		assert.strictEqual(htmlStr, element.innerHTML);
+	});
+
 	it('should render escaped html inside element via incremental dom', function() {
 		let element = document.createElement('div');
 		IncrementalDOM.patch(element, () => HTML2IncDom.run('&#39;Foo&#39;'));


### PR DESCRIPTION
This fixes #371, with references.

* https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements
* https://www.w3schools.com/html/html_blocks.asp