### PR TITLE
fix for 🐛 #378

### DIFF
--- a/packages/metal-dom/src/domNamed.js
+++ b/packages/metal-dom/src/domNamed.js
@@ -765,14 +765,7 @@ export function toElement(selectorOrElement) {
 	) {
 		return selectorOrElement;
 	} else if (isString(selectorOrElement)) {
-		if (
-			selectorOrElement[0] === '#' &&
-			selectorOrElement.indexOf(' ') === -1
-		) {
-			return document.getElementById(selectorOrElement.substr(1));
-		} else {
-			return document.querySelector(selectorOrElement);
-		}
+		return document.querySelector(selectorOrElement);
 	} else {
 		return null;
 	}

--- a/packages/metal-dom/test/domNamed.js
+++ b/packages/metal-dom/test/domNamed.js
@@ -1,0 +1,22 @@
+'use strict';
+
+import dom from '../src/all/dom';
+import {toElement} from '../src/domNamed';
+
+describe('domNamed', function() {
+	describe('toElement', function() {
+		it('should match string selectors', function() {
+			let parent = document.createElement('div');
+			let child = document.createElement('div');
+			parent.id = 'parent';
+			dom.addClasses(child, 'child');
+			dom.append(parent, child);
+			dom.append(document.body, parent);
+
+			assert.strictEqual(parent, toElement('#parent'));
+			assert.strictEqual(child, toElement('.child'));
+			assert.strictEqual(child, toElement('#parent>.child'));
+			assert.strictEqual(child, toElement('#parent > .child'));
+		});
+	});
+});


### PR DESCRIPTION
Removed condition to switch between `getElementById` and `querySelector` in `toElement` method.

First of all because the conditions does not handle well edge cases as stated in the issue #378, and then because the performance gain obtained using `getElementById` is lost executing the condition in almost every browser. (some tests here: https://jsperf.com/conditional-getelementbyid)