### PR TITLE
Escapes html entities inside element attributes

### DIFF
--- a/packages/metal-incremental-dom/src/html/HTML2IncDom.js
+++ b/packages/metal-incremental-dom/src/html/HTML2IncDom.js
@@ -37,7 +37,7 @@ class HTML2IncDom {
 					: IncrementalDOM.elementOpen;
 				let args = [tag, null, []];
 				for (let i = 0; i < attrs.length; i++) {
-					args.push(attrs[i].name, attrs[i].value);
+					args.push(attrs[i].name, unescape(attrs[i].value));
 				}
 				fn(...args);
 			},

--- a/packages/metal-incremental-dom/test/html/HTML2IncDom.js
+++ b/packages/metal-incremental-dom/test/html/HTML2IncDom.js
@@ -40,6 +40,14 @@ describe('HTML2IncDom', function() {
 		assert.strictEqual(htmlStr, element.innerHTML);
 	});
 
+	it('should unescape html entities inside element attributes', function() {
+		let element = document.createElement('div');
+		let htmlStr =
+			'<form action="actionurl?foo=&quot;&lt;2&quot;&amp;bar=&gt;bar"></form>';
+		IncrementalDOM.patch(element, () => HTML2IncDom.run(htmlStr));
+		assert.strictEqual(htmlStr, element.innerHTML);
+	});
+
 	describe('setParser', function() {
 		afterEach(function() {
 			HTML2IncDom.setParser(null);


### PR DESCRIPTION
Hey @eduardolundgren, @brunobasto, what do you think about this? We aren't properly unescaping attribute values before passing it down to incremental-dom, which is causing some complex issues.

I think this should be safe since all tests are passing and I added an additional one... 🤔 

/cc @topolik